### PR TITLE
Move partition filter to table-level properties

### DIFF
--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py
@@ -37,6 +37,7 @@ def generate_config(context):
         'schema',
         'timePartitioning',
         'clustering',
+        'requirePartitionFilter',
         'view'
     ]
 

--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
@@ -67,6 +67,7 @@ properties:
       requirePartitionFilter:
         type: boolean
         description: |
+          DEPRECATED. Please set the field with the same name on the table itself.
           If True, queries over the table require a partition filter
           (that can be used for partition elimination) to be specified.
       type:
@@ -87,6 +88,11 @@ properties:
           will be generated, so it is important.
         items:
           type: string
+  requirePartitionFilter:
+    type: boolean
+    description: |
+      Optional. If set to true, queries over this table require a partition filter 
+      that can be used for partition elimination to be specified.
   view:
     type: object
     description: The view definintion.


### PR DESCRIPTION
Move partition filter to table-level properties hence it is deprecated on time partitioning level

https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TimePartitioning
